### PR TITLE
Fix tets of cell

### DIFF
--- a/spec/conway/GOL/cell_spec.rb
+++ b/spec/conway/GOL/cell_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe Conway::Cell do
 
   describe '#Initialize' do
     it 'should be the value x of instance' do
-      expect(cell.x).to eq(0)
+      expect(cell.pos_x).to eq(0)
     end
     it 'should be the value y of instance' do
-      expect(cell.y).to eq(0)
+      expect(cell.pos_y).to eq(0)
     end
     it 'should be dead' do
       expect(cell.alive).not_to eq(true)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require "bundler/setup"
-require "conway/GOL"
+require "conway"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
The spec helper was modified in the require of the files and the cell_spec change the variables x and y.